### PR TITLE
[SDC-1757] Added logic to pause the scanner when away from window (#96)

### DIFF
--- a/Native/ExtendedSample/Droid/PickerViewRenderer.cs
+++ b/Native/ExtendedSample/Droid/PickerViewRenderer.cs
@@ -34,6 +34,7 @@ namespace ExtendedSample.Droid
 
                 e.NewElement.StartScanningRequested += OnStartScanningRequested;
                 e.NewElement.PauseScanningRequested += OnPauseScanningRequested;
+                e.NewElement.StopScanningRequested += OnStopScanningRequested;
 
                 barcodePicker = new BarcodePicker(context, CreateScanSettings());
                 SetNativeControl(barcodePicker.OverlayView.RootView);
@@ -51,6 +52,7 @@ namespace ExtendedSample.Droid
             {
                 e.OldElement.StartScanningRequested -= OnStartScanningRequested;
                 e.OldElement.PauseScanningRequested -= OnPauseScanningRequested;
+                e.OldElement.StopScanningRequested -= OnStopScanningRequested;
             }
         }
 
@@ -65,6 +67,11 @@ namespace ExtendedSample.Droid
         private void OnPauseScanningRequested(object sender, EventArgs e)
         {
             barcodePicker.PauseScanning();
+        }
+
+        private void OnStopScanningRequested(object sender, EventArgs e)
+        {
+            barcodePicker.StopScanning();
         }
 
         private ScanSettings CreateScanSettings()

--- a/Native/ExtendedSample/ExtendedSample/App.xaml.cs
+++ b/Native/ExtendedSample/ExtendedSample/App.xaml.cs
@@ -14,16 +14,22 @@ namespace ExtendedSample
         protected override void OnStart()
         {
             base.OnStart();
+
+            ((MainPage)this.MainPage).StartScanning();
         }
 
         protected override void OnSleep()
         {
             base.OnSleep();
+
+            ((MainPage)this.MainPage).StopScanning();
         }
 
         protected override void OnResume()
         {
             base.OnResume();
+
+            ((MainPage)this.MainPage).StartScanning();
         }
     }
 }

--- a/Native/ExtendedSample/ExtendedSample/MainPage.cs
+++ b/Native/ExtendedSample/ExtendedSample/MainPage.cs
@@ -19,6 +19,12 @@ namespace ExtendedSample
             Children.Add(settingsPage);
         }
 
+        public void StopScanning() => scannerPage.StopScanning();
+
+        public void StartScanning() => scannerPage.ResumeScanning();
+
+        public void PauseScanning() => scannerPage.PauseScanning();
+
         protected override void OnCurrentPageChanged()
         {
             base.OnCurrentPageChanged();

--- a/Native/ExtendedSample/ExtendedSample/PickerView.cs
+++ b/Native/ExtendedSample/ExtendedSample/PickerView.cs
@@ -7,6 +7,8 @@ namespace ExtendedSample
     {
 		public event EventHandler StartScanningRequested;
 		public event EventHandler PauseScanningRequested;
+		public event EventHandler StopScanningRequested;
+
 		public IScannerDelegate Delegate { get; set; }
 		public Settings Settings { get; set; }
 
@@ -23,6 +25,11 @@ namespace ExtendedSample
         public void PauseScanning()
         {
             PauseScanningRequested?.Invoke(this, EventArgs.Empty);
+        }
+
+        public void StopScanning()
+        {
+            StopScanningRequested?.Invoke(this, EventArgs.Empty);
         }
 
         public void DidScan(string symbology, string code)

--- a/Native/ExtendedSample/ExtendedSample/ScannerPage.xaml.cs
+++ b/Native/ExtendedSample/ExtendedSample/ScannerPage.xaml.cs
@@ -55,6 +55,11 @@ namespace ExtendedSample
         {
             PickerView.PauseScanning();
         }
+
+        public void StopScanning()
+        {
+            PickerView.StopScanning();
+        }
     }
 
     public class ScannerDelegate : IScannerDelegate

--- a/Native/ExtendedSample/iOS/PickerViewRenderer.cs
+++ b/Native/ExtendedSample/iOS/PickerViewRenderer.cs
@@ -31,6 +31,7 @@ namespace ExtendedSample.iOS
 
                 e.NewElement.StartScanningRequested += OnStartScanningRequested;
                 e.NewElement.PauseScanningRequested += OnPauseScanningRequested;
+                e.NewElement.StopScanningRequested += OnStopScanningRequested;
 
                 barcodePicker = new RotationSettingAwareBarcodePicker(CreateScanSettings());
                 SetNativeControl(barcodePicker.View);
@@ -48,6 +49,7 @@ namespace ExtendedSample.iOS
             {
                 e.OldElement.StartScanningRequested -= OnStartScanningRequested;
                 e.OldElement.PauseScanningRequested -= OnPauseScanningRequested;
+                e.OldElement.StopScanningRequested -= OnStopScanningRequested;
             }
         }
 
@@ -68,6 +70,11 @@ namespace ExtendedSample.iOS
         private void OnPauseScanningRequested(object sender, EventArgs e)
         {
             barcodePicker.PauseScanning();
+        }
+
+        private void OnStopScanningRequested(object sender, EventArgs e)
+        {
+            barcodePicker.StopScanning();
         }
 
         private ScanSettings CreateScanSettings()


### PR DESCRIPTION
* Added logic to pause the scanner whenever app goes into background to save battery life.
* Implemented in Xamarin.Forms App Lifecycle based on the https://docs.microsoft.com/en-us/xamarin/xamarin-forms/app-fundamentals/app-lifecycle

(cherry picked from commit c107e3ad58daaaac459af075a0cb95a10fedd9d6)